### PR TITLE
Add Django 1.11 compatibility.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,16 +6,14 @@ python:
 sudo: false
 
 env:
-    - TOXENV="py35-django1.9"
-    - TOXENV="py34-django1.9"
-    - TOXENV="py27-django1.9"
-    - TOXENV="py35-django1.8"
-    - TOXENV="py34-django1.8"
-    - TOXENV="py33-django1.8"
     - TOXENV="py27-django1.8"
+    - TOXENV="py35-django1.8"
+    - TOXENV="py27-django1.9"
+    - TOXENV="py35-django1.9"
     - TOXENV="py27-django1.10"
     - TOXENV="py35-django1.10"
-    - TOXENV="py34-django1.10"
+    - TOXENV="py27-django1.11"
+    - TOXENV="py35-django1.11"
     - TOXENV="flake8"
 
 matrix:

--- a/djcelery/tests/test_admin.py
+++ b/djcelery/tests/test_admin.py
@@ -83,4 +83,4 @@ class TestPeriodicTaskAdmin(TestCase):
             kwargs = {query: 'Queen'}
             # We have no content, so the number of results if we search on
             # something should be zero.
-            self.assertEquals(PeriodicTask.objects.filter(**kwargs).count(), 0)
+            self.assertEqual(PeriodicTask.objects.filter(**kwargs).count(), 0)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27-django{1.8,1.9,1.10}, py33-django1.8, py{34,35}-django{1.8,1.9,1.10}, flake8
+envlist = py{27,35}-django{1.8,1.9,1.10,1.11}, flake8
 
 [testenv]
 sitepackages = False
@@ -9,6 +9,7 @@ deps =
     django1.8: Django>=1.8.0,<1.9.0
     django1.9: Django>=1.9.0,<1.10.0
     django1.10: Django>=1.10.0,<1.11.0
+    django1.11: Django>=1.11.0,<2.0
 
 setenv =
     PYTHONPATH={toxinidir}/tests


### PR DESCRIPTION
django-celery proper doesn't have official Django 1.11 support. This PR adds it.