### PR TITLE
Bump version to 3.2.1+edx.1

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -5,7 +5,17 @@
 .. contents::
     :local:
 
-.. _version-3.2.0:
+.. _version-3.2.1+edx.1:
+
+3.2.1+edx.1
+===========
+:release-date: 2017-08-04
+
+- Django 1.11 testing and support
+
+- Version bump for edX fork for proper re-installation.
+
+.. _version-3.2.0
 
 3.2.0
 =====
@@ -28,7 +38,7 @@
 - Fixed Django 1.10 compatibility issue in scheduler
 
     Fix contributed by Mathieu Fenniak.
-    
+
 - Fixed Django 1.10 compatibility issue in management commands
 
     Fix contributed by Stranger6667, yjmade and Vytis Banaitis.

--- a/djcelery/__init__.py
+++ b/djcelery/__init__.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, unicode_literals
 import os
 import sys
 
-VERSION = (3, 2, 0)
+VERSION = (3, 2, 1, '+edx.1')
 __version__ = '.'.join(map(str, VERSION[0:3])) + ''.join(VERSION[3:])
 __author__ = 'Ask Solem'
 __contact__ = 'ask@celeryproject.org'


### PR DESCRIPTION
edx-platform will temporarily use this edX fork of django-celery until Celery is upgraded to v4.
edx-platform currently installs django-celery v3.2.1. That version was *not* on master in the upstream repo - it was on an unmerged branch:
https://github.com/celery/django-celery/compare/master...v3.2.1

This PR bumps the version on the edX fork to avoid confusion around the installation of django-celery. Bumping the version will cause installation of the edX fork version on all edx-platform installations.