### PR TITLE
Fix rate limiting admin action for Django 1.10

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -5,6 +5,14 @@
 .. contents::
     :local:
 
+.. _version-3.2.1+edx.2:
+
+3.2.1+edx.2
+===========
+:release-date: 2017-12-08
+
+- Fix the rate limiting Django admin action to work with Django 1.10+
+
 .. _version-3.2.1+edx.1:
 
 3.2.1+edx.1

--- a/djcelery/__init__.py
+++ b/djcelery/__init__.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, unicode_literals
 import os
 import sys
 
-VERSION = (3, 2, 1, '+edx.1')
+VERSION = (3, 2, 1, '+edx.2')
 __version__ = '.'.join(map(str, VERSION[0:3])) + ''.join(VERSION[3:])
 __author__ = 'Ask Solem'
 __contact__ = 'ask@celeryproject.org'

--- a/djcelery/admin.py
+++ b/djcelery/admin.py
@@ -8,8 +8,7 @@ from django.contrib import admin
 from django.contrib.admin import helpers
 from django.contrib.admin.views import main as main_views
 from django.forms.widgets import Select
-from django.shortcuts import render_to_response
-from django.template import RequestContext
+from django.shortcuts import render
 from django.utils.html import escape
 from django.utils.translation import ugettext_lazy as _
 
@@ -195,10 +194,7 @@ class TaskMonitor(ModelMonitor):
             'app_label': app_label,
         }
 
-        return render_to_response(
-            self.rate_limit_confirmation_template, context,
-            context_instance=RequestContext(request),
-        )
+        return render(request, self.rate_limit_confirmation_template, context)
 
     def get_actions(self, request):
         actions = super(TaskMonitor, self).get_actions(request)

--- a/djcelery/db.py
+++ b/djcelery/db.py
@@ -27,7 +27,7 @@ except ImportError:  # pragma: no cover
                 transaction.managed(True, *args, **kwargs)
                 try:
                     yield
-                except:
+                except:  # noqa
                     if transaction.is_dirty(*args, **kwargs):
                         transaction.rollback(*args, **kwargs)
                     raise
@@ -35,7 +35,7 @@ except ImportError:  # pragma: no cover
                     if transaction.is_dirty(*args, **kwargs):
                         try:
                             transaction.commit(*args, **kwargs)
-                        except:
+                        except:  # noqa
                             transaction.rollback(*args, **kwargs)
                             raise
             finally:

--- a/setup.py
+++ b/setup.py
@@ -182,7 +182,7 @@ setup(
     zip_safe=False,
     install_requires=[
         'celery>=3.1.15,<4.0',
-        'django>=1.8',
+        'django>=1.8,<2.0',
     ],
     cmdclass={'test': RunTests,
               'quicktest': QuickRunTests,


### PR DESCRIPTION
This admin action apparently isn't being tested, but might get triggered manually in production.  It'll stop working in 1.10 without this change because the `context_instance` parameter is being removed from `render_to_response()`.

I also had to add an upper bound on the Django dependency in setup.py because otherwise installation chokes trying to run Django 2.0's Python 3-only setup.py under Python 2.7.  Also suppressed a couple of new flake8 warnings.